### PR TITLE
Update NextAuth + minimist to patch security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3118,9 +3118,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mmd-parser": {
@@ -3204,9 +3204,9 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.3.1.tgz",
-      "integrity": "sha512-DBYEPBLq5naIqh/1i2zEHljcA1OXXecKW3NRU1W4s6R3UX3RdLZ2lWlqgBHUiZQ1zdNikFM/bYQxVGyG7bx8oA==",
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.10.3.tgz",
+      "integrity": "sha512-7zc4aXYc/EEln7Pkcsn21V1IevaTZsMLJwapfbnKA4+JY0+jFzWbt5p/ljugesGIrN4VOZhpZIw50EaFZyghJQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.3",
         "@panva/hkdf": "^1.0.1",
@@ -3223,8 +3223,8 @@
       },
       "peerDependencies": {
         "nodemailer": "^6.6.5",
-        "react": "^17.0.2 || ^18.0.0-0",
-        "react-dom": "^17.0.2 || ^18.0.0-0"
+        "react": "^17.0.2 || ^18",
+        "react-dom": "^17.0.2 || ^18"
       },
       "peerDependenciesMeta": {
         "nodemailer": {
@@ -7006,9 +7006,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mmd-parser": {
@@ -7074,9 +7074,9 @@
       }
     },
     "next-auth": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.3.1.tgz",
-      "integrity": "sha512-DBYEPBLq5naIqh/1i2zEHljcA1OXXecKW3NRU1W4s6R3UX3RdLZ2lWlqgBHUiZQ1zdNikFM/bYQxVGyG7bx8oA==",
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.10.3.tgz",
+      "integrity": "sha512-7zc4aXYc/EEln7Pkcsn21V1IevaTZsMLJwapfbnKA4+JY0+jFzWbt5p/ljugesGIrN4VOZhpZIw50EaFZyghJQ==",
       "requires": {
         "@babel/runtime": "^7.16.3",
         "@panva/hkdf": "^1.0.1",


### PR DESCRIPTION
```minimist  <1.2.6
Severity: critical
Prototype Pollution in minimist - https://github.com/advisories/GHSA-xvch-5gv4-984h
fix available via `npm audit fix`
node_modules/minimist

next-auth  4.0.0 - 4.10.2
Severity: critical
NextAuth.js default redirect callback vulnerable to open redirects - https://github.com/advisories/GHSA-f9wg-5f46-cjmw
URL Redirection to Untrusted Site ('Open Redirect') in next-auth - https://github.com/advisories/GHSA-q2mx-j4x2-2h74
Improper handling of email input - https://github.com/advisories/GHSA-pgjx-7f9g-9463
Improper Handling of `callbackUrl` parameter in next-auth - https://github.com/advisories/GHSA-g5fm-jp9v-2432
next-auth before v4.10.2 and v3.29.9 leaks excessive information into log - https://github.com/advisories/GHSA-p6mm-27gq-9v3p   
NextAuth.js before 4.10.3 and 3.29.10 sending verification requests (magic link) to unwanted emails - https://github.com/advisories/GHSA-xv97-c62v-4587
fix available via `npm audit fix`
```