### PR TITLE
Update getStaticPaths in /course/[id].tsx to ignore PEA000

### DIFF
--- a/pages/course/[id].tsx
+++ b/pages/course/[id].tsx
@@ -372,9 +372,13 @@ const CoursePage = ({
 export async function getStaticPaths() {
   const courses = getAllCourses();
 
-  const paths = courses.map((course) => ({
-    params: { id: course.course_no },
-  }));
+  const paths = courses
+    .filter((course) => course.course_no !== 'PEA000')
+    .map((course) => {
+      return {
+        params: { id: course.course_no },
+      };
+    });
 
   return { paths, fallback: false };
 }


### PR DESCRIPTION
/course/PEA000 is a hard-coded path, and will not have an auto-generated page.