### PR TITLE
Patch: Using unstable_getServerSession to replace client getSession

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,13 +1,14 @@
 // Each provider represents a way for the user to log in
-import nextAuth from 'next-auth';
+import nextAuth, { NextAuthOptions, Session, User } from 'next-auth';
 import azureADProvider from 'next-auth/providers/azure-ad';
 import emailProvider from 'next-auth/providers/email';
 import googleProvider from 'next-auth/providers/google';
 // Adapters give NextAuth a way to communicate with the database
 import { MongoDBAdapter } from '@next-auth/mongodb-adapter';
+import { JWT } from 'next-auth/jwt';
 import clientPromise from '../../../lib/mongodb';
 
-export default nextAuth({
+export const AuthOptions: NextAuthOptions = {
   providers: [
     azureADProvider({
       clientId: process.env.AZURE_AD_CLIENT_ID ?? '',
@@ -27,19 +28,21 @@ export default nextAuth({
     colorScheme: 'light',
   },
   callbacks: {
-    async jwt({ token }) {
+    async jwt({ token }: { token: JWT }) {
       return token;
     },
-    async session({ session, user }) {
+    async session({ session, user }: { session: Session; user: User }) {
       session.user = {
         id: user.id,
         name: user.name,
         email: user.email,
-        courses: user.courses,
+        courses: user.courses || [],
       };
 
       return session;
     },
   },
   adapter: MongoDBAdapter(clientPromise),
-});
+};
+
+export default nextAuth(AuthOptions);

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,10 +1,13 @@
 import { AnimatePresence, motion } from 'framer-motion';
 import { GetServerSideProps } from 'next';
-import { getSession, useSession } from 'next-auth/react';
+// eslint-disable-next-line camelcase
+import { unstable_getServerSession } from 'next-auth';
+import { useSession } from 'next-auth/react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useState } from 'react';
 import { MdExpandMore } from 'react-icons/md';
+import { AuthOptions } from './api/auth/[...nextauth]';
 
 const SubRequirement = ({
   description,
@@ -413,7 +416,11 @@ const Profile = () => {
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const session = await getSession(context);
+  const session = await unstable_getServerSession(
+    context.req,
+    context.res,
+    AuthOptions
+  );
 
   if (!session) {
     return {


### PR DESCRIPTION
The method getSession caused a deployment error (turns out I do write wrong code) when viewing /profile on production: no matter what if you're logged in you won't be able to view the page. I suspect this had to do with client-side session, this is a patch. Expect a rollback if this does not work.